### PR TITLE
feat(ldap): 增加 filter 支持，限制允许登录的用户范围

### DIFF
--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -53,6 +53,8 @@ type LdapConfig struct {
 	UserPrefix      string `json:"userPrefix"`
 	DefaultUserRole string `json:"defaultUserRole"`
 	Cronjob         string `json:"cronjob"`
+	// Filter 用于限制允许登录的用户范围，例如: (&(objectClass=person)(memberOf=cn=jms,ou=groups,dc=test,dc=com))
+	Filter string `json:"filter"`
 }
 
 type OidcConfig struct {

--- a/internal/services/ldap.go
+++ b/internal/services/ldap.go
@@ -73,6 +73,11 @@ func (l ldapService) ListUsers() ([]ldapUser, error) {
 	pages := 0
 	pagingControl := ldap.NewControlPaging(pageSize)
 
+	listFilter := "(objectClass=person)"
+	if l.ldapConfig.Filter != "" {
+		listFilter = fmt.Sprintf("(&%s(objectClass=person))", l.ldapConfig.Filter)
+	}
+
 	for {
 		pages++
 
@@ -82,7 +87,7 @@ func (l ldapService) ListUsers() ([]ldapUser, error) {
 			ldap.ScopeWholeSubtree,
 			ldap.NeverDerefAliases,
 			0, 0, false,
-			"(objectClass=person)",
+			listFilter,
 			[]string{"sAMAccountName", "cn", "mail", "mobile"},
 			[]ldap.Control{pagingControl},
 		)
@@ -190,12 +195,17 @@ func (l ldapService) Login(username, password string) error {
 	defer auth.Close()
 
 	// 先搜索用户，获取真实的DN
+	loginFilter := fmt.Sprintf("(sAMAccountName=%s)", ldap.EscapeFilter(username))
+	if l.ldapConfig.Filter != "" {
+		loginFilter = fmt.Sprintf("(&%s(sAMAccountName=%s))", l.ldapConfig.Filter, ldap.EscapeFilter(username))
+	}
+
 	searchRequest := ldap.NewSearchRequest(
 		l.ldapConfig.BaseDN,
 		ldap.ScopeWholeSubtree,
 		ldap.NeverDerefAliases,
 		1, 0, false,
-		fmt.Sprintf("(sAMAccountName=%s)", ldap.EscapeFilter(username)),
+		loginFilter,
 		[]string{"dn"},
 		nil,
 	)


### PR DESCRIPTION
## 变更说明

- 在 `models/settings.go` 的 `LdapConfig` 结构体中新增 `filter` 字段
- `Login` 方法：若设置了 `filter`，使用 AND 逻辑将其与用户名搜索条件合并，只有同时满足两个条件的用户才能登录
- `ListUsers` 方法：若设置了 `filter`，将其与 `(objectClass=person)` 合并，限制同步到 W8T 的用户范围

## 配置示例

```yaml
Ldap:
  enabled: true
  address: "192.168.1.100:389"
  baseDN: "dc=test,dc=com"
  adminUser: "cn=admin,dc=test,dc=com"
  adminPass: "test123."
  userDN: "ou=people,dc=test,dc=com"
  userPrefix: "uid"
  defaultUserRole: "ur-cq7nkj1d6gviooaigqi0"
  cronjob: "*/1 * * * *"
  # 只允许 jms 组内的用户登录
  filter: "(&(objectClass=person)(memberOf=cn=jms,ou=groups,dc=test,dc=com))"
**实现逻辑**
- filter 为空时（默认），行为与原来一致，baseDN 下所有用户均可登录
- filter 不为空时，搜索条件自动合并：
   登录验证：(&<filter>(sAMAccountName=<username>))
   用户同步：(&<filter>(objectClass=person))
关联 Issue: #174
