### PR TITLE
feat: 支持按标签配置告警阈值覆盖

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ dist-ssr
 deploy/docker-compose/mysql
 deploy/docker-compose/redis
 
+.codex
+*.tar.gz

--- a/alert/eval/query.go
+++ b/alert/eval/query.go
@@ -15,6 +15,8 @@ import (
 	"github.com/zeromicro/go-zero/core/logc"
 )
 
+const ThresholdModeNodeOverride = "node_override"
+
 // Metrics Prometheus 数据源
 func metrics(ctx *ctx.Context, datasourceId, datasourceType string, rule models.AlertRule) []string {
 	pools := ctx.Redis.ProviderPools()
@@ -57,15 +59,15 @@ func metrics(ctx *ctx.Context, datasourceId, datasourceType string, rule models.
 		return nil
 	}
 
-	// 按优先级排序规则（P0 > P1 > P2）
-	rules := sortRulesByPriority(rule.PrometheusConfig.Rules)
-
 	for _, v := range resQuery {
 		// 避免共享引用导致的指纹不一致问题
 		metricLabels := make(map[string]interface{})
 		for k, val := range v.GetMetric() {
 			metricLabels[k] = val
 		}
+
+		// 按当前指标标签选择阈值规则，未命中覆盖配置时回退默认规则。
+		rules := sortRulesByPriority(selectPrometheusRules(rule.PrometheusConfig, metricLabels))
 
 		// 使用独立的标签副本来生成指纹，避免修改原始数据
 		fingerprintLabels := make(map[string]interface{})
@@ -119,7 +121,7 @@ func metrics(ctx *ctx.Context, datasourceId, datasourceType string, rule models.
 			event.Fingerprint = fingerprint
 			event.Severity = ruleExpr.Severity
 			event.SearchQL = fmt.Sprintf("%s %s %v", rule.PrometheusConfig.PromQL, operator, value)
-			event.ForDuration = rule.GetForDuration(ruleExpr.Severity)
+			event.ForDuration = ruleExpr.ForDuration
 			event.Annotations = tools.ParserVariables(rule.PrometheusConfig.Annotations, tools.ConvertStructToMap(event))
 			event.Status = models.StatePreAlert
 
@@ -151,6 +153,43 @@ func metrics(ctx *ctx.Context, datasourceId, datasourceType string, rule models.
 	}
 
 	return curFingerprints
+}
+
+func selectPrometheusRules(config models.PrometheusConfig, metricLabels map[string]interface{}) []models.Rules {
+	if config.ThresholdMode != ThresholdModeNodeOverride {
+		return config.Rules
+	}
+
+	for _, override := range config.ThresholdOverrides {
+		if len(override.Rules) == 0 {
+			continue
+		}
+
+		if matchMetricLabels(metricLabels, override.MatchLabels) {
+			return override.Rules
+		}
+	}
+
+	return config.Rules
+}
+
+func matchMetricLabels(metricLabels map[string]interface{}, matchLabels map[string]string) bool {
+	if len(matchLabels) == 0 {
+		return false
+	}
+
+	for key, expected := range matchLabels {
+		actual, ok := metricLabels[key]
+		if !ok {
+			return false
+		}
+
+		if fmt.Sprintf("%v", actual) != expected {
+			return false
+		}
+	}
+
+	return true
 }
 
 // sortRulesByPriority 按优先级排序规则

--- a/alert/eval/query_test.go
+++ b/alert/eval/query_test.go
@@ -1,0 +1,118 @@
+package eval
+
+import (
+	"reflect"
+	"testing"
+	"watchAlert/internal/models"
+)
+
+func TestSelectPrometheusRulesReturnsDefaultRulesWhenModeIsEmpty(t *testing.T) {
+	defaultRules := []models.Rules{
+		{Severity: "P0", Expr: "> 95", ForDuration: 300},
+	}
+
+	got := selectPrometheusRules(models.PrometheusConfig{
+		Rules: defaultRules,
+	}, map[string]interface{}{
+		"instance": "node-a:9100",
+	})
+
+	if !reflect.DeepEqual(got, defaultRules) {
+		t.Fatalf("expected default rules, got %#v", got)
+	}
+}
+
+func TestSelectPrometheusRulesReturnsOverrideRulesWhenLabelsMatch(t *testing.T) {
+	defaultRules := []models.Rules{
+		{Severity: "P0", Expr: "> 95", ForDuration: 300},
+	}
+	overrideRules := []models.Rules{
+		{Severity: "P0", Expr: "> 98", ForDuration: 600},
+	}
+
+	got := selectPrometheusRules(models.PrometheusConfig{
+		Rules:         defaultRules,
+		ThresholdMode: ThresholdModeNodeOverride,
+		ThresholdOverrides: []models.ThresholdOverride{
+			{
+				MatchLabels: map[string]string{"instance": "node-a:9100"},
+				Rules:       overrideRules,
+			},
+		},
+	}, map[string]interface{}{
+		"instance": "node-a:9100",
+	})
+
+	if !reflect.DeepEqual(got, overrideRules) {
+		t.Fatalf("expected override rules, got %#v", got)
+	}
+}
+
+func TestSelectPrometheusRulesFallsBackToDefaultRulesWhenLabelsDoNotMatch(t *testing.T) {
+	defaultRules := []models.Rules{
+		{Severity: "P0", Expr: "> 95", ForDuration: 300},
+	}
+	overrideRules := []models.Rules{
+		{Severity: "P0", Expr: "> 98", ForDuration: 600},
+	}
+
+	got := selectPrometheusRules(models.PrometheusConfig{
+		Rules:         defaultRules,
+		ThresholdMode: ThresholdModeNodeOverride,
+		ThresholdOverrides: []models.ThresholdOverride{
+			{
+				MatchLabels: map[string]string{"instance": "node-a:9100"},
+				Rules:       overrideRules,
+			},
+		},
+	}, map[string]interface{}{
+		"instance": "node-b:9100",
+	})
+
+	if !reflect.DeepEqual(got, defaultRules) {
+		t.Fatalf("expected default rules, got %#v", got)
+	}
+}
+
+func TestSelectPrometheusRulesSkipsEmptyOverrideRules(t *testing.T) {
+	defaultRules := []models.Rules{
+		{Severity: "P0", Expr: "> 95", ForDuration: 300},
+	}
+
+	got := selectPrometheusRules(models.PrometheusConfig{
+		Rules:         defaultRules,
+		ThresholdMode: ThresholdModeNodeOverride,
+		ThresholdOverrides: []models.ThresholdOverride{
+			{
+				MatchLabels: map[string]string{"instance": "node-a:9100"},
+			},
+		},
+	}, map[string]interface{}{
+		"instance": "node-a:9100",
+	})
+
+	if !reflect.DeepEqual(got, defaultRules) {
+		t.Fatalf("expected default rules, got %#v", got)
+	}
+}
+
+func TestMatchMetricLabelsRequiresAllLabelsToMatch(t *testing.T) {
+	metricLabels := map[string]interface{}{
+		"instance": "node-a:9100",
+		"os_type":  "Linux",
+	}
+
+	if !matchMetricLabels(metricLabels, map[string]string{
+		"instance": "node-a:9100",
+		"os_type":  "Linux",
+	}) {
+		t.Fatal("expected all labels to match")
+	}
+
+	if matchMetricLabels(metricLabels, map[string]string{
+		"instance": "node-a:9100",
+		"os_type":  "Windows",
+	}) {
+		t.Fatal("expected mismatched label to fail")
+	}
+}

--- a/internal/models/rule.go
+++ b/internal/models/rule.go
@@ -98,12 +98,20 @@ type PrometheusConfig struct {
 	Annotations string `json:"annotations"`
 	//ForDuration int64   `json:"forDuration"`
 	Rules []Rules `json:"rules"`
+
+	ThresholdMode      string              `json:"thresholdMode"`
+	ThresholdOverrides []ThresholdOverride `json:"thresholdOverrides"`
 }
 
 type Rules struct {
 	ForDuration int64  `json:"forDuration"`
 	Severity    string `json:"severity"`
 	Expr        string `json:"expr"`
+}
+
+type ThresholdOverride struct {
+	MatchLabels map[string]string `json:"matchLabels"`
+	Rules       []Rules           `json:"rules"`
 }
 
 type EffectiveTime struct {


### PR DESCRIPTION
### 变更说明

本 PR 为 Prometheus 告警规则增加按指标标签配置阈值覆盖的能力。

在保留原有全局阈值规则的基础上，允许用户针对特定指标标签配置独立的告警条件，例如按 `instance`、`hostname`、`job`、`os_type` 等标签设置不同阈值。

### 背景

实际生产环境中，同一类节点或同一条 PromQL 告警规则下，不同节点可能需要不同阈值。

例如：

- 节点 A 内存阈值为 98%
- 节点 B 内存阈值为 95%

如果为每个节点复制一条告警规则，规则数量会膨胀，维护成本较高。

### 主要改动

- Prometheus 规则配置增加阈值覆盖字段
- 告警评估时根据当前指标 labels 匹配覆盖规则
- 命中覆盖规则时使用覆盖阈值
- 未命中覆盖规则时回退原有全局规则
- 支持覆盖规则中的独立 `severity`、`expr`、`forDuration`
- 保持旧规则兼容，未配置覆盖字段时行为不变
- 增加阈值覆盖匹配逻辑的单元测试

### 兼容性

兼容已有规则。

如果规则中没有配置 `thresholdMode` 或 `thresholdOverrides`，告警评估逻辑仍使用原有全局 `rules`，不会改变现有行为。

当前覆盖规则按配置顺序匹配，第一条命中的覆盖规则生效。建议将更具体的标签匹配项放在更前面。

### 关联 Issue
Refs opsre/WatchAlert#ISSUE_ID